### PR TITLE
Fixing correlation to matrix header alignment

### DIFF
--- a/q2_ps_qc/actions/generate_corr_matrix.py
+++ b/q2_ps_qc/actions/generate_corr_matrix.py
@@ -247,6 +247,10 @@ def generate_corr_matrix(
 
     score_fh.close()
 
+    # align correlation reps to input matrix cols
+    bad_corr_replicates = [rep for rep in replicates if rep in bad_corr_replicates]
+    good_corr_replicates = [rep for rep in replicates if rep in good_corr_replicates]
+
     # Create Zscore matrix and metadata for bad correlation replicates
     generate_corr_tsv(data, "bad_corr.tsv", bad_corr_replicates)
     bad_metadata = generate_metadata(bad_corr_replicates)


### PR DESCRIPTION
Added two lines which reorders the replicates in the good and bad correlation replicate lists back into the order they were received from the input matrix.